### PR TITLE
Update scc.cpp

### DIFF
--- a/scc.cpp
+++ b/scc.cpp
@@ -10,32 +10,41 @@
 #include <string.h>
 
 int main(void) {
-  char s[1024];
+  char s[1024],ch;
   int count=0, states;
   
-/* 1,2
- * States読み取りの段階で状態数がわかるのでこれをもとに配列を用意
- * SCCグラフの計算はTransitionsによる状態ノード間のつながりの情報だけあればできるはず */
   do {
     fgets(s,1024,stdin); count++;
-    //    fputs(s,stdout);
   } while (strncmp(s,"init",4)!=0);
 
   states = count-4;
 
-  printf("%d\n",states);
-
   int path[states][states];
-  int src,dst;
+  int src,dst,i,j;
+
+  for (i=0; i<states; i++) {
+    for (j=0; j<states; j++) {
+      path[i][j] = 0;
+    }
+  }
   
-  scanf("%d", &src);
-  scanf("::");
-  scanf("%d", &path[src][dst]);
+  for (i=0; i<states; i++) {
+    scanf("%d::",&src);
+    if (scanf("%d",&dst) == 0) continue;
+    path[src-1][dst-1]=1;
+    while ((ch = getchar()) == ',') {
+      scanf("%d",&dst);
+      path[src-1][dst-1] = 1;
+    }
+  }
 
-  printf("%d\n", path[src][dst]);
-// 3
-
-// 4
+  for (i=0; i<states; i++) {
+    printf("%d",path[i][0]);
+    for (j=1; j<states; j++) {
+      printf(" %d",path[i][j]);
+    }
+    printf("\n");
+  }
   
   return 0;
 }


### PR DESCRIPTION
could read all transitions
to manipulate reachability data, transition src->dst is associated to path[src-1][dst-1] = 1
this indicates that shortest path from src to dst includes 1 transitions
if i could make the path[][] of type pointer but not int, that makes path include the content of path (but a bit difficult for me now, so i will split the branch)